### PR TITLE
[マイページ]出品一覧画面に画像を表示

### DIFF
--- a/app/assets/stylesheets/user_show.scss
+++ b/app/assets/stylesheets/user_show.scss
@@ -2,17 +2,14 @@
   padding:40px 0;
   background-color: #f8f8f8;
   .contentsMain {
-    height: calc(100% - 120px);
-    margin:0 auto;
+    margin:0 200px;
     display: flex;
     ul {
       margin:0 auto;
-      // box-sizing: border-box;
       flex-direction: column;
       align-items: center;
         li {
           height: 60px;
-          // display: block;
           color: #fff;
           font-size: 18px;
           position: relative;

--- a/app/assets/stylesheets/user_show.scss
+++ b/app/assets/stylesheets/user_show.scss
@@ -51,6 +51,7 @@
       .content{
         display: none;
         color: black;
+        padding-bottom: 50px;
         background-color: #fff;
         .contentTitle{
           text-align: center;
@@ -68,6 +69,10 @@
             .contentInfo__list {
               font-weight: normal;
             }
+          }
+          &__none{
+            text-align: center;
+            margin-top: 50px;
           }
         }
       }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -54,6 +54,9 @@
                 = product.product_name
               .contentInfo__image
                 = image_tag product.images[0].src.url, size: "150x100"
+        - unless @product.present?
+          .contentInfo__none
+            出品している製品はありません
       %li#tab__favorite.content
         .contentTitle
           お気に入り一覧
@@ -63,6 +66,9 @@
               商品名
               .contentInfo__list
                 = favorite.product.product_name
+        - unless @favorite.present?
+          .contentInfo__none
+            お気に入り登録している製品はありません
 
 .footer
   =render "devise/footer"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -72,3 +72,10 @@
 
 .footer
   =render "devise/footer"
+-if user_signed_in?
+  .exhibition
+    = link_to new_product_path, data: {"turbolinks": false} do
+      -# 商品出品ページへ遷移
+      .exhibition__content
+        %P 出品する
+        = image_tag("icon_camera.png")

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -52,6 +52,8 @@
               商品名
               .contentInfo__list
                 = product.product_name
+              .contentInfo__image
+                = image_tag product.images[0].src.url, size: "150x100"
       %li#tab__favorite.content
         .contentTitle
           お気に入り一覧
@@ -61,9 +63,6 @@
               商品名
               .contentInfo__list
                 = favorite.product.product_name
-                
-        
-
 
 .footer
   =render "devise/footer"


### PR DESCRIPTION
## What
・contentInfoクラス内に、contentInfo__imageクラスを追加
・contentsMainクラスのmarginを変更
・その他ビューを整えるため軽微な修正
・リファクタリング

## Why
ユーザビリティ向上のため

マイページ内で出品一覧をクリックした際に、該当の画像を表示するように設定。